### PR TITLE
Allow null numbers

### DIFF
--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -1724,7 +1724,7 @@
         <field name="SECSTD" length="8" type="string"/>
         <field name="SECCOMP" length="8" type="string"/>
         <field name="SECLEN" length="5" type="integer"/>
-        <field name="SECURITY" length_var="SECLEN" type="binary"/>
+        <field name="SECURITY" length_var="SECLEN" type="string"/>
     </tre>
 
     <tre name="SENSRA" length="132" location="image">

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -1717,6 +1717,16 @@
         <field length="1" fixed_value="0"/>
     </tre>
 
+    <tre name="SECURA">
+        <field name="FDATTIM" length="14" type="string"/>
+        <field name="NITFVER" length="9" type="string"/>
+        <field name="NFSECFLDS" length="207" type="string"/>
+        <field name="SECSTD" length="8" type="string"/>
+        <field name="SECCOMP" length="8" type="string"/>
+        <field name="SECLEN" length="5" type="integer"/>
+        <field name="SECURITY" length_var="SECLEN" type="binary"/>
+    </tre>
+
     <tre name="SENSRA" length="132" location="image">
         <field name="REF_ROW" length="8" type="string"/>
         <field name="REF_COL" length="8" type="string"/>

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/SECURA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/SECURA_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.codice.imaging.nitf.core.common.NitfReader;
+import org.codice.imaging.nitf.core.common.impl.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.codice.imaging.nitf.core.tre.TreCollection;
+import org.codice.imaging.nitf.core.tre.TreSource;
+import org.junit.Test;
+
+/**
+ * Tests for SECURA TRE parsing.
+ *
+ * This TRE is described in STDI-0002-1 Appendix AI: SECURA 1.0
+ *
+ */
+public class SECURA_Test {
+
+    public SECURA_Test() {
+    }
+
+    @Test
+    public void SimpleSECURA() throws Exception {
+        InputStream inputStream = new ByteArrayInputStream("SECURA0228720200423091801NITF02.10                                                                                                                                                                                                               ARH XML         02036<?xml version=\"1.0\" encoding=\"UTF-8\"?> <arh:Security   xmlns:arh=\"urn:us:gov:ic:arh\"   xmlns:ism=\"urn:us:gov:ic:ism\"   xmlns:ntk=\"urn:us:gov:is:ntk\"   ism:compliesWith=\"USGov USIC\"   ism:DESVersion=\"201609.201707\"   ism:ISMCATCESVersion=\"201707\"   ism:resourceElement=\"true\"   arh:DESVersion=\"3\"   ntk:DESVersion=\"201508\"   ism:createDate=\"2006-05-04\"   ism:classification=\"U\"   ism:ownerProducer=\"USA\">   <ntk:Access ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ntk:RequiresAnyOf>       <ntk:AccessProfileList xmlns=\"urn:us:gov:ic:ntk\">         <ntk:AccessProfile ism:classification=\"U\" ism:ownerProducer=\"USA\">           <ntk:AccessPolicy>urn:us:gov:ic:aces:ntk:permissive</ntk:AccessPolicy>           <ntk:ProfileDes>urn:us:gov:ic:ntk:profile:grp-ind</ntk:ProfileDes>           <ntk:VocabularyType ntk:name=\"individual:unclasssourceforge\"             ntk:source=\"UnclassSourceForge\"/>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">johndoe</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">ssun</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cjhodges</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cgilsenan</ntk:AccessProfileValue>         </ntk:AccessProfile>       </ntk:AccessProfileList>     </ntk:RequiresAnyOf>   </ntk:Access>   <ism:NoticeList ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">Memorial day is on May 28th 2012</ism:NoticeText>     </ism:Notice>     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">The next Holiday will be July 4th 2012</ism:NoticeText>     </ism:Notice>   </ism:NoticeList> </arh:Security>".getBytes());
+        BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        TreCollection parseResult = parser.parse(nitfReader, 39, TreSource.UserDefinedHeaderData);
+        assertEquals(1, parseResult.getTREs().size());
+        Tre secura = parseResult.getTREsWithName("SECURA").get(0);
+        assertNotNull(secura);
+        assertNull(secura.getRawData());
+        assertEquals(7, secura.getEntries().size());
+        assertEquals("20200423091801", secura.getFieldValue("FDATTIM"));
+        assertEquals("NITF02.10", secura.getFieldValue("NITFVER"));
+        assertEquals("                                                                                                                                                                                                               ", secura.getFieldValue("NFSECFLDS"));
+        assertEquals("ARH XML ", secura.getFieldValue("SECSTD"));
+        assertEquals("        ", secura.getFieldValue("SECCOMP"));
+        assertEquals("02036", secura.getFieldValue("SECLEN"));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?> <arh:Security   xmlns:arh=\"urn:us:gov:ic:arh\"   xmlns:ism=\"urn:us:gov:ic:ism\"   xmlns:ntk=\"urn:us:gov:is:ntk\"   ism:compliesWith=\"USGov USIC\"   ism:DESVersion=\"201609.201707\"   ism:ISMCATCESVersion=\"201707\"   ism:resourceElement=\"true\"   arh:DESVersion=\"3\"   ntk:DESVersion=\"201508\"   ism:createDate=\"2006-05-04\"   ism:classification=\"U\"   ism:ownerProducer=\"USA\">   <ntk:Access ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ntk:RequiresAnyOf>       <ntk:AccessProfileList xmlns=\"urn:us:gov:ic:ntk\">         <ntk:AccessProfile ism:classification=\"U\" ism:ownerProducer=\"USA\">           <ntk:AccessPolicy>urn:us:gov:ic:aces:ntk:permissive</ntk:AccessPolicy>           <ntk:ProfileDes>urn:us:gov:ic:ntk:profile:grp-ind</ntk:ProfileDes>           <ntk:VocabularyType ntk:name=\"individual:unclasssourceforge\"             ntk:source=\"UnclassSourceForge\"/>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">johndoe</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">ssun</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cjhodges</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cgilsenan</ntk:AccessProfileValue>         </ntk:AccessProfile>       </ntk:AccessProfileList>     </ntk:RequiresAnyOf>   </ntk:Access>   <ism:NoticeList ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">Memorial day is on May 28th 2012</ism:NoticeText>     </ism:Notice>     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">The next Holiday will be July 4th 2012</ism:NoticeText>     </ism:Notice>   </ism:NoticeList> </arh:Security>", secura.getFieldValue("SECURITY"));
+    }
+}

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
@@ -54,12 +54,12 @@ public class SECURA extends TreWrapper {
     /**
      * Invalid version message.
      */
-    protected static final String INVALID_VERSION = "NITF version {s}  is not NITF 2.0 nor NITF 2.1.";
+    protected static final String INVALID_VERSION = "NITF version %s is not NITF 2.0 nor NITF 2.1.";
 
     /**
      *  Invalid security standard message.
      */
-    protected static final String INVALID_SECURITY_STANDARD = "Security Standard {s} is not registered with the NITF Technical Board.";
+    protected static final String INVALID_SECURITY_STANDARD = "Security Standard %s is not registered with the NITF Technical Board.";
 
     /**
      * Invalid compression message.

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.trewrap;
+
+import static org.codice.imaging.nitf.core.common.FileType.NITF_TWO_ONE;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.impl.DateTimeParser;
+import org.codice.imaging.nitf.core.common.impl.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.security.SecurityMetadata;
+import org.codice.imaging.nitf.core.security.impl.SecurityMetadataParser;
+import org.codice.imaging.nitf.core.tre.Tre;
+
+/**
+ * Wrapper for the Extended Security Marking Metadata (SECURA) TRE.
+ *
+ * From STDI-0002-1 Appendix AI: SECURA 1.0
+ * The Extended Security Marking Metadata (SECURA) Tagged Record Extension (TRE) was developed to
+ * provide additional security marking metadata for NITF 2.0 and NITF 2.1 files. NITF was developed
+ * in the 1990s and the security data available in the file header and subheaders was based on the
+ * requirements of that time. This TRE is designed to supplement the original data in a general
+ * manner to be fully flexible moving forward and allow ingest by any systems into the National
+ * System for Geospatial Intelligence (NSG). Using SECURA, security marking metadata can be provided
+ * using ODNI Intelligence Community Technical Specification, XML Data Encoding Specification for
+ * Access Rights and Handling (ARH.XML)
+ *
+ */
+public class SECURA extends FlatTreWrapper {
+
+    /**
+     * Flag value that indicates that the True Map Angle.
+     */
+    private static final String TAG_NAME = "SECURA";
+
+    /**
+     * Create a SECURA TRE wrapper from an existing TRE.
+     *
+     * @param tre the TRE to wrap. Must match the ACFTB tag.
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public SECURA(final Tre tre) throws NitfFormatException {
+        super(tre, TAG_NAME);
+    }
+
+    /**
+     * Get the NITF Date Time Field.
+     *
+     * Byte copy of the associated FDT field in the NITF file.  CCYYMMDDhhmmss( NITF 2.1) DDHHMMSSZMONYY (NITF 2.0)
+     *
+     * @return the Nitf Date Time Field as a string.
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final DateTime getNitfDateTimeField() throws NitfFormatException {
+        InputStream stream = new ByteArrayInputStream(getValueAsTrimmedString("FDATTIM").getBytes(StandardCharsets.UTF_8));
+        NitfInputStreamReader nitfReader = new NitfInputStreamReader(stream);
+        nitfReader.setFileType(getNitfVersion());
+        DateTimeParser dateTimeParser = new DateTimeParser();
+        return dateTimeParser.readNitfDateTime(nitfReader);
+    }
+
+    /**
+     * Get the NITF version field value.
+     *
+     * The version of the NITF file.
+     *
+     * @return the FileType enum.
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final FileType getNitfVersion() throws NitfFormatException {
+        return FileType.getEnumValue(getValueAsTrimmedString("NITFVER"));
+    }
+
+    /**
+     * Get the NITF Security Fields.
+     *
+     * Associated segment's security fields.
+     *
+     * @return a SecurityMetadata object.
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final SecurityMetadata getNitfSecurityFields() throws NitfFormatException {
+        final SecurityMetadata securityMetadata;
+        if (getNitfVersion() == NITF_TWO_ONE || getNitfVersion() == FileType.NITF_TWO_ZERO) {
+            InputStream stream = new ByteArrayInputStream(getFieldValue("NFSECFLDS").getBytes(StandardCharsets.UTF_8));
+            SecurityMetadataParser parser = new SecurityMetadataParser();
+            NitfInputStreamReader nitfReader = new NitfInputStreamReader(stream);
+            nitfReader.setFileType(getNitfVersion());
+            securityMetadata = parser.parseSecurityMetadata(nitfReader);
+        } else {
+            securityMetadata = null;
+                throw new NitfFormatException("Could not parse Security Fields");
+        }
+        return securityMetadata;
+    }
+
+    /**
+     * Get Security Standard field value.
+     *
+     * The security standard used to populate the SECURITY field.
+     *
+     * @return the security standard string
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final String getSecurityStandard() throws NitfFormatException {
+        return getValueAsTrimmedString("SECSTD");
+    }
+
+    /**
+     * Get the SECURITY field compression.
+     *
+     * This field identifies the compression used, if any, of the SECURITY field.
+     *
+     * @return the SECURITY field compression string
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final String getSecurityFieldCompression() throws NitfFormatException {
+        return getValueAsTrimmedString("SECCOMP");
+    }
+
+    /**
+     * Get the length of the SECURITY field.
+     *
+     * This field holds the length of the SECURITY field in bytes.
+     *
+     * @return SECURITY field length
+     * @throws NitfFormatException if there is a parsing issue on the NITF side
+     */
+    public final int getSecurityLength() throws NitfFormatException {
+        return getValueAsInteger("SECLEN");
+    }
+
+    /**
+     * Get the Security field value.
+     *
+     * The actual security data, as encoded using the security standard specified in the
+     * SECSTD field and compressed as specified by the SECCOMP field.
+     *
+     * @return the Security data
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final byte[] getSecurity() throws NitfFormatException {
+        return getFieldValue("SECURITY").getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    /**
+     * Get the Security field value.
+     *
+     * The actual security data, as encoded using the security standard specified in the
+     * SECSTD field and compressed as specified by the SECCOMP field.
+     *
+     * @return the uncompressed Security data
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public final String getSecurityUncompressed() throws NitfFormatException {
+        if (getSecurityFieldCompression().equals("GZIP")) {
+            byte[] security = getSecurity();
+
+            StringBuilder sb = new StringBuilder();
+            try (ByteArrayInputStream bis = new ByteArrayInputStream(security);
+            GZIPInputStream gis = new GZIPInputStream(bis);
+            BufferedReader br = new BufferedReader(new InputStreamReader(gis, StandardCharsets.ISO_8859_1))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+            }
+            } catch (IOException e) {
+                throw new NitfFormatException("Could not uncompress SECURITY field." + e.getLocalizedMessage());
+            }
+            return sb.toString();
+        }
+        return getFieldValue("SECURITY");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final ValidityResult getValidity() throws NitfFormatException {
+        // TODO: add more validity checks
+        return new ValidityResult();
+    }
+}

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
@@ -73,7 +73,7 @@ public class SECURA extends FlatTreWrapper {
      * @throws NitfFormatException if there is a parsing issue.
      */
     public final DateTime getNitfDateTimeField() throws NitfFormatException {
-        InputStream stream = new ByteArrayInputStream(getValueAsTrimmedString("FDATTIM").getBytes(StandardCharsets.UTF_8));
+        InputStream stream = new ByteArrayInputStream(getValueAsTrimmedString("FDATTIM").getBytes(StandardCharsets.ISO_8859_1));
         NitfInputStreamReader nitfReader = new NitfInputStreamReader(stream);
         nitfReader.setFileType(getNitfVersion());
         DateTimeParser dateTimeParser = new DateTimeParser();

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/SECURA.java
@@ -193,7 +193,7 @@ public class SECURA extends TreWrapper {
             StringBuilder sb = new StringBuilder();
             try (ByteArrayInputStream bis = new ByteArrayInputStream(security);
             GZIPInputStream gis = new GZIPInputStream(bis);
-            BufferedReader br = new BufferedReader(new InputStreamReader(gis, StandardCharsets.ISO_8859_1))) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(gis, StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 sb.append(line);
@@ -203,7 +203,7 @@ public class SECURA extends TreWrapper {
             }
             return sb.toString();
         }
-        return getFieldValue("SECURITY");
+        return new String(getSecurity(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/ValidityResult.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/ValidityResult.java
@@ -33,7 +33,7 @@ public class ValidityResult {
          * At least one issue with the TRE values was detected during validity checks.
          */
         NOT_VALID
-    };
+    }
 
     private ValidityStatus mValidityStatus = ValidityStatus.VALID;
 
@@ -45,6 +45,18 @@ public class ValidityResult {
      * The default values are that the result is valid.
      */
     public ValidityResult() {
+    }
+
+    /**
+     * Create a new validity result.
+     *
+     * @param validityStatus VALID for no issues, NOT_VALID if issues are found
+     * @param validityResultDescription  Description for reason field is invalid
+     */
+
+    public ValidityResult(final ValidityStatus validityStatus, final String validityResultDescription) {
+        mValidityStatus = validityStatus;
+        mValidityResultDescription = validityResultDescription;
     }
 
     /**

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.trewrap;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.security.SecurityClassification;
+import org.codice.imaging.nitf.core.security.SecurityMetadata;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Assert;
+import org.junit.Test;
+
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+/**
+ * Tests for the SECURA wrapper.
+ */
+public class SECURA_WrapTest extends SharedTreTestSupport {
+
+    TestLogger LOGGER = TestLoggerFactory.getTestLogger(TreWrapper.class);
+    private final String securityUncompressedLength = "02036";
+    private final String securityUncompressed = "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <arh:Security   xmlns:arh=\"urn:us:gov:ic:arh\"   xmlns:ism=\"urn:us:gov:ic:ism\"   xmlns:ntk=\"urn:us:gov:is:ntk\"   ism:compliesWith=\"USGov USIC\"   ism:DESVersion=\"201609.201707\"   ism:ISMCATCESVersion=\"201707\"   ism:resourceElement=\"true\"   arh:DESVersion=\"3\"   ntk:DESVersion=\"201508\"   ism:createDate=\"2006-05-04\"   ism:classification=\"U\"   ism:ownerProducer=\"USA\">   <ntk:Access ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ntk:RequiresAnyOf>       <ntk:AccessProfileList xmlns=\"urn:us:gov:ic:ntk\">         <ntk:AccessProfile ism:classification=\"U\" ism:ownerProducer=\"USA\">           <ntk:AccessPolicy>urn:us:gov:ic:aces:ntk:permissive</ntk:AccessPolicy>           <ntk:ProfileDes>urn:us:gov:ic:ntk:profile:grp-ind</ntk:ProfileDes>           <ntk:VocabularyType ntk:name=\"individual:unclasssourceforge\"             ntk:source=\"UnclassSourceForge\"/>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">johndoe</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">ssun</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cjhodges</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cgilsenan</ntk:AccessProfileValue>         </ntk:AccessProfile>       </ntk:AccessProfileList>     </ntk:RequiresAnyOf>   </ntk:Access>   <ism:NoticeList ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">Memorial day is on May 28th 2012</ism:NoticeText>     </ism:Notice>     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">The next Holiday will be July 4th 2012</ism:NoticeText>     </ism:Notice>   </ism:NoticeList> </arh:Security>";
+    private final String securityCompressedLength = "00576";
+    private final byte[] secuirtyGzipped = compress(securityUncompressed);
+    private final String mTestData20 = "SECURA0228723091801ZAPR20NITF02.00" +
+            "                                                                                                                                                                                                               " +
+            "ARH XML         " + securityUncompressedLength + securityUncompressed;
+
+    private final String mTestData21 = "SECURA0228720200423091801NITF02.10" +
+            "                                                                                                                                                                                                               " +
+            "ARH XML         " + securityUncompressedLength + securityUncompressed;
+
+    private final String mTestDataGzip = "SECURA0082720200423091801NITF02.10" +
+            "                                                                                                                                                                                                               " +
+            "ARH XML GZIP    " + securityCompressedLength;
+
+    private final String mTestDataBadCompression = "SECURA0228720200423091801NITF02.10" +
+            "                                                                                                                                                                                                               " +
+            "ARH XML GZIP    " + securityUncompressedLength + securityUncompressed;
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public SECURA_WrapTest() {
+    }
+
+    @Test
+    public void testNitf21Gzipped() throws NitfFormatException {
+        Tre tre = parseTRE(buildTREBytes(), "SECURA");
+        SECURA secura = new SECURA(tre);
+        assertTrue(secura.getValidity().isValid());
+        assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
+        assertEquals(FileType.NITF_TWO_ONE, secura.getNitfVersion());
+        checkNitf21SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
+        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("GZIP", secura.getSecurityFieldCompression());
+        assertEquals(576, secura.getSecurityLength());
+        String uncompressed = uncompress(secuirtyGzipped);
+        assertEquals(uncompressed, securityUncompressed);
+        assertArrayEquals(secuirtyGzipped, secura.getSecurity());
+        assertEquals(securityUncompressed, secura.getSecurityUncompressed());
+    }
+
+    @Test
+    public void testGettersNitf20() throws NitfFormatException {
+        Tre tre = parseTRE(mTestData20, "SECURA");
+        SECURA secura = new SECURA(tre);
+        assertTrue(secura.getValidity().isValid());
+        assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
+        assertEquals(FileType.NITF_TWO_ZERO, secura.getNitfVersion());
+        checkNitf20SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
+        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("", secura.getSecurityFieldCompression());
+        assertEquals(2036, secura.getSecurityLength());
+        assertEquals(securityUncompressed, new String(secura.getSecurity(), StandardCharsets.ISO_8859_1));
+        assertEquals(securityUncompressed, secura.getSecurityUncompressed());
+    }
+
+    @Test
+    public void testGettersNitf21() throws NitfFormatException {
+        Tre tre = parseTRE(mTestData21, "SECURA");
+        SECURA secura = new SECURA(tre);
+        assertTrue(secura.getValidity().isValid());
+        assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
+        assertEquals(FileType.NITF_TWO_ONE, secura.getNitfVersion());
+        checkNitf21SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
+        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("", secura.getSecurityFieldCompression());
+        assertEquals(2036, secura.getSecurityLength());
+        assertEquals(securityUncompressed, new String(secura.getSecurity(), StandardCharsets.ISO_8859_1));
+        assertEquals(securityUncompressed, secura.getSecurityUncompressed());
+    }
+
+    @Test(expected = NitfFormatException.class)
+    public void testBadCompression() throws NitfFormatException {
+        Tre tre = parseTRE(mTestDataBadCompression, "SECURA");
+        SECURA secura = new SECURA(tre);
+        String test = secura.getSecurityUncompressed();
+    }
+
+
+    public static void checkNitf20SecurityMetadataUnclasAndEmpty(SecurityMetadata securityMetadata) {
+        assertNotNull(securityMetadata);
+        assertEquals(SecurityClassification.UNKNOWN, securityMetadata.getSecurityClassification());
+        assertNull(securityMetadata.getSecurityClassificationSystem());
+        assertEquals("", securityMetadata.getCodewords());
+        assertEquals("", securityMetadata.getControlAndHandling());
+        assertEquals("", securityMetadata.getReleaseInstructions());
+        assertNull(securityMetadata.getDeclassificationType());
+        assertNull(securityMetadata.getDeclassificationDate());
+        assertNull(securityMetadata.getDeclassificationExemption());
+        assertNull(securityMetadata.getDowngrade());
+        assertNull(securityMetadata.getDowngradeDate());
+        assertNull(securityMetadata.getClassificationText());
+        assertNull(securityMetadata.getClassificationAuthorityType());
+        assertEquals("", securityMetadata.getClassificationAuthority());
+        assertNull(securityMetadata.getClassificationReason());
+        assertEquals("", securityMetadata.getSecurityControlNumber());
+    }
+
+    public static void checkNitf21SecurityMetadataUnclasAndEmpty(SecurityMetadata securityMetadata) {
+        Assert.assertEquals(SecurityClassification.UNKNOWN, securityMetadata.getSecurityClassification());
+        assertEquals("", securityMetadata.getSecurityClassificationSystem());
+        assertEquals("", securityMetadata.getCodewords());
+        assertEquals("", securityMetadata.getControlAndHandling());
+        assertEquals("", securityMetadata.getReleaseInstructions());
+        assertEquals("", securityMetadata.getDeclassificationType());
+        assertEquals("", securityMetadata.getDeclassificationDate());
+        assertEquals("", securityMetadata.getDeclassificationExemption());
+        assertEquals("", securityMetadata.getDowngrade());
+        assertEquals("", securityMetadata.getDowngradeDate());
+        assertEquals("", securityMetadata.getClassificationText());
+        assertEquals("", securityMetadata.getClassificationAuthorityType());
+        assertEquals("", securityMetadata.getClassificationAuthority());
+        assertEquals("", securityMetadata.getClassificationReason());
+        assertEquals("", securityMetadata.getSecurityControlNumber());
+    }
+
+    private static byte[] compress(String data) {
+        byte[] compressed = null;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(bos);) {
+            gzip.write(data.getBytes(StandardCharsets.ISO_8859_1));
+            // in order to get the full set of bytes you must close the output stream.
+            gzip.close();
+            compressed = bos.toByteArray();
+        } catch (Exception ex) {
+            System.out.println(ex.getLocalizedMessage());
+        }
+        return compressed;
+    }
+
+    private final String uncompress(byte[] compressed) throws NitfFormatException {
+            StringBuilder sb = new StringBuilder();
+            try (ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+                    GZIPInputStream gis = new GZIPInputStream(bis);
+                    BufferedReader br = new BufferedReader(new InputStreamReader(gis));) {
+                String line;
+                while((line = br.readLine()) != null) {
+                    sb.append(line);
+                }
+            } catch (IOException e) {
+                throw new NitfFormatException("Could not uncompress SECURITY field.");
+            }
+            return sb.toString();
+    }
+
+    private final byte[] buildTREBytes() {
+        String result;
+        String defaltEncoding = System.getProperty("file.encoding");
+        Charset defaultCharset = Charset.forName(defaltEncoding);
+        Charset iso88591charset = Charset.forName("ISO-8859-1");
+
+
+        ByteBuffer inputBuffer = ByteBuffer.wrap(mTestDataGzip.getBytes());
+
+        // decode UTF-8
+        CharBuffer data = defaultCharset.decode(inputBuffer);
+
+        // encode ISO-8559-1
+        ByteBuffer outputBuffer = iso88591charset.encode(data);
+        byte[] outputData = outputBuffer.array();
+        byte[] gzipped = new byte[outputData.length + secuirtyGzipped.length];
+
+        System.arraycopy(outputData, 0, gzipped, 0, outputData.length);
+        System.arraycopy(secuirtyGzipped, 0, gzipped, outputData.length, secuirtyGzipped.length);
+
+        return gzipped;
+    }
+}

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
@@ -54,21 +54,37 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
     private final String securityUncompressed = "<?xml version=\"1.0\" encoding=\"UTF-8\"?> <arh:Security   xmlns:arh=\"urn:us:gov:ic:arh\"   xmlns:ism=\"urn:us:gov:ic:ism\"   xmlns:ntk=\"urn:us:gov:is:ntk\"   ism:compliesWith=\"USGov USIC\"   ism:DESVersion=\"201609.201707\"   ism:ISMCATCESVersion=\"201707\"   ism:resourceElement=\"true\"   arh:DESVersion=\"3\"   ntk:DESVersion=\"201508\"   ism:createDate=\"2006-05-04\"   ism:classification=\"U\"   ism:ownerProducer=\"USA\">   <ntk:Access ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ntk:RequiresAnyOf>       <ntk:AccessProfileList xmlns=\"urn:us:gov:ic:ntk\">         <ntk:AccessProfile ism:classification=\"U\" ism:ownerProducer=\"USA\">           <ntk:AccessPolicy>urn:us:gov:ic:aces:ntk:permissive</ntk:AccessPolicy>           <ntk:ProfileDes>urn:us:gov:ic:ntk:profile:grp-ind</ntk:ProfileDes>           <ntk:VocabularyType ntk:name=\"individual:unclasssourceforge\"             ntk:source=\"UnclassSourceForge\"/>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">johndoe</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">ssun</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cjhodges</ntk:AccessProfileValue>           <ntk:AccessProfileValue ntk:vocabulary=\"individual:unclasssourceforge\">cgilsenan</ntk:AccessProfileValue>         </ntk:AccessProfile>       </ntk:AccessProfileList>     </ntk:RequiresAnyOf>   </ntk:Access>   <ism:NoticeList ism:classification=\"U\" ism:ownerProducer=\"USA\">     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">Memorial day is on May 28th 2012</ism:NoticeText>     </ism:Notice>     <ism:Notice ism:classification=\"U\" ism:ownerProducer=\"USA\" ism:unregisteredNoticeType=\"Holiday\">       <ism:NoticeText ism:classification=\"U\" ism:ownerProducer=\"USA\">The next Holiday will be July 4th 2012</ism:NoticeText>     </ism:Notice>   </ism:NoticeList> </arh:Security>";
     private final String securityCompressedLength = "00576";
     private final byte[] secuirtyGzipped = compress(securityUncompressed);
-    private final String mTestData20 = "SECURA0228723091801ZAPR20NITF02.00" +
-            "                                                                                                                                                                                                               " +
-            "ARH XML         " + securityUncompressedLength + securityUncompressed;
+    private final String nitf20 = "NITF02.00";
+    private final String nitf21 = "NITF02.10";
+    private final String invalidVersion = "NITF02.22";
+    private final String nitfSecurityFields = "                                                                                                                                                                                                               ";
+    private final String securityStandard = "ARH.XML ";
+    private final String invalidsecurityStandard = "XXX.XML ";
+    private final String seccompUncompressed = "        ";
+    private final String seccompCompressed = "GZIP    ";
+    private final String seccompInvalid = "ZIP     ";
 
-    private final String mTestData21 = "SECURA0228720200423091801NITF02.10" +
-            "                                                                                                                                                                                                               " +
-            "ARH XML         " + securityUncompressedLength + securityUncompressed;
+    private final String mTestData20 = "SECURA0228723091801ZAPR20" + nitf20 + nitfSecurityFields +
+            securityStandard + seccompUncompressed + securityUncompressedLength + securityUncompressed;
 
-    private final String mTestDataGzip = "SECURA0082720200423091801NITF02.10" +
-            "                                                                                                                                                                                                               " +
-            "ARH XML GZIP    " + securityCompressedLength;
+    private final String mTestData21 = "SECURA0228720200423091801" + nitf21 + nitfSecurityFields +
+            securityStandard + seccompUncompressed + securityUncompressedLength + securityUncompressed;
 
-    private final String mTestDataBadCompression = "SECURA0228720200423091801NITF02.10" +
-            "                                                                                                                                                                                                               " +
-            "ARH XML GZIP    " + securityUncompressedLength + securityUncompressed;
+    private final String mTestDataGzip = "SECURA0082720200423091801" + nitf21 + nitfSecurityFields +
+            securityStandard + seccompCompressed + securityCompressedLength;
+
+    private final String mTestDataBadCompression = "SECURA0228720200423091801NITF02.10" + nitf21 + nitfSecurityFields +
+            securityStandard + seccompCompressed + securityUncompressedLength + securityUncompressed;
+
+    private final String mTestInvalidVersion = "SECURA0228720200423091801" + invalidVersion + nitfSecurityFields +
+            securityStandard + seccompUncompressed + securityUncompressedLength + securityUncompressed;
+
+    private final String mTestInvlaidSecurityStandard = "SECURA0228720200423091801" + nitf21 + nitfSecurityFields +
+            invalidsecurityStandard + seccompUncompressed + securityUncompressedLength + securityUncompressed;
+
+    private final String mTestInvalidCompression = "SECURA0228720200423091801" + nitf21 + nitfSecurityFields +
+            securityStandard + seccompInvalid + securityUncompressedLength + securityUncompressed;
+
 
     private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -83,7 +99,7 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
         assertEquals(FileType.NITF_TWO_ONE, secura.getNitfVersion());
         checkNitf21SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
-        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("ARH.XML", secura.getSecurityStandard());
         assertEquals("GZIP", secura.getSecurityFieldCompression());
         assertEquals(576, secura.getSecurityLength());
         String uncompressed = uncompress(secuirtyGzipped);
@@ -100,7 +116,7 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
         assertEquals(FileType.NITF_TWO_ZERO, secura.getNitfVersion());
         checkNitf20SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
-        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("ARH.XML", secura.getSecurityStandard());
         assertEquals("", secura.getSecurityFieldCompression());
         assertEquals(2036, secura.getSecurityLength());
         assertEquals(securityUncompressed, new String(secura.getSecurity(), StandardCharsets.ISO_8859_1));
@@ -115,7 +131,7 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         assertEquals("2020-04-23 09:18:01", formatter.format(secura.getNitfDateTimeField().getZonedDateTime()));
         assertEquals(FileType.NITF_TWO_ONE, secura.getNitfVersion());
         checkNitf21SecurityMetadataUnclasAndEmpty(secura.getNitfSecurityFields());
-        assertEquals("ARH XML", secura.getSecurityStandard());
+        assertEquals("ARH.XML", secura.getSecurityStandard());
         assertEquals("", secura.getSecurityFieldCompression());
         assertEquals(2036, secura.getSecurityLength());
         assertEquals(securityUncompressed, new String(secura.getSecurity(), StandardCharsets.ISO_8859_1));
@@ -127,6 +143,30 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         Tre tre = parseTRE(mTestDataBadCompression, "SECURA");
         SECURA secura = new SECURA(tre);
         String test = secura.getSecurityUncompressed();
+    }
+
+    @Test
+    public void testInvalidNitfVersion() throws NitfFormatException {
+        Tre tre = parseTRE(mTestInvalidVersion, "SECURA");
+        SECURA secura = new SECURA(tre);
+        String error = secura.getValidity().getValidityResultDescription();
+        assertEquals(error, SECURA.INVALID_VERSION);
+    }
+
+    @Test
+    public void testInvalidSecurityStandard() throws NitfFormatException {
+        Tre tre = parseTRE(mTestInvlaidSecurityStandard, "SECURA");
+        SECURA secura = new SECURA(tre);
+        String error = secura.getValidity().getValidityResultDescription();
+        assertEquals(error, SECURA.INVALID_SECURITY_STANDARD);
+    }
+
+    @Test
+    public void mTestInvalidCompression() throws NitfFormatException {
+        Tre tre = parseTRE(mTestInvalidCompression, "SECURA");
+        SECURA secura = new SECURA(tre);
+        String error = secura.getValidity().getValidityResultDescription();
+        assertEquals(error, SECURA.INVALID_COMPRESSION);
     }
 
 

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SECURA_WrapTest.java
@@ -150,7 +150,7 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         Tre tre = parseTRE(mTestInvalidVersion, "SECURA");
         SECURA secura = new SECURA(tre);
         String error = secura.getValidity().getValidityResultDescription();
-        assertEquals(error, SECURA.INVALID_VERSION);
+        assertEquals(error, String.format(SECURA.INVALID_VERSION, secura.getNitfVersion().getTextEquivalent()));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SECURA_WrapTest extends SharedTreTestSupport {
         Tre tre = parseTRE(mTestInvlaidSecurityStandard, "SECURA");
         SECURA secura = new SECURA(tre);
         String error = secura.getValidity().getValidityResultDescription();
-        assertEquals(error, SECURA.INVALID_SECURITY_STANDARD);
+        assertEquals(error, String.format(SECURA.INVALID_SECURITY_STANDARD, secura.getSecurityStandard()));
     }
 
     @Test

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SharedTreTestSupport.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SharedTreTestSupport.java
@@ -36,8 +36,12 @@ public abstract class SharedTreTestSupport {
     }
 
     protected Tre parseTRE(String testData, String treTag) throws NitfFormatException {
-        InputStream inputStream = new ByteArrayInputStream(testData.getBytes());
-        return parseTRE(inputStream, testData.length(), treTag);
+        return parseTRE(testData.getBytes(), treTag);
+    }
+
+    protected Tre parseTRE(byte[] testData, String treTag) throws NitfFormatException {
+        InputStream inputStream = new ByteArrayInputStream(testData);
+        return parseTRE(inputStream, testData.length, treTag);
     }
 
     protected Tre parseTRE(InputStream inputStream, int len, String treTag) throws NitfFormatException {


### PR DESCRIPTION
A NITF where the numbers are represented by spaces will be parsed, but will fail when it is written.

Updates the validation to allow the representation of null numbers (both integer and real) with BCS spaces.  The PIATGB TRE allows the TGTLAT and TGTLON to be null if the target location is unknown.  It also allows for blank spaces to represent the degree of accuracy of the location.

